### PR TITLE
Update to Spring Cloud Config 3.0.1 #33

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Spring Cloud Config Server
 A docker image of [Spring Cloud Config Server](https://docs.spring.io/spring-cloud-config/docs/3.0.1/reference/html/).
 
-![GitHub tag (latest by date)](https://img.shields.io/github/v/tag/hyness/spring-cloud-config-server)
+![GitHub tag (latest SemVer)](https://img.shields.io/github/v/tag/hyness/spring-cloud-config-server?style=flat-square)
 ![GitHub Workflow Status (branch)](https://img.shields.io/github/workflow/status/hyness/spring-cloud-config-server/CI/master)
 [![Docker Stars](https://img.shields.io/docker/stars/hyness/spring-cloud-config-server.svg?style=flat-square)](https://hub.docker.com/r/hyness/spring-cloud-config-server/)
 [![Docker Pulls](https://img.shields.io/docker/pulls/hyness/spring-cloud-config-server.svg?style=flat-square)](https://hub.docker.com/r/hyness/spring-cloud-config-server)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Spring Cloud Config Server
-A docker image of [Spring Cloud Config Server](https://docs.spring.io/spring-cloud-config/docs/3.0.0/reference/html/).
+A docker image of [Spring Cloud Config Server](https://docs.spring.io/spring-cloud-config/docs/3.0.1/reference/html/).
 
-![GitHub tag (latest SemVer)](https://img.shields.io/github/v/tag/hyness/spring-cloud-config-server?style=flat-square)
+![GitHub tag (latest by date)](https://img.shields.io/github/v/tag/hyness/spring-cloud-config-server)
+![GitHub Workflow Status (branch)](https://img.shields.io/github/workflow/status/hyness/spring-cloud-config-server/CI/master)
 [![Docker Stars](https://img.shields.io/docker/stars/hyness/spring-cloud-config-server.svg?style=flat-square)](https://hub.docker.com/r/hyness/spring-cloud-config-server/)
 [![Docker Pulls](https://img.shields.io/docker/pulls/hyness/spring-cloud-config-server.svg?style=flat-square)](https://hub.docker.com/r/hyness/spring-cloud-config-server)
 [![Docker Automated build](https://img.shields.io/docker/automated/hyness/spring-cloud-config-server.svg?style=flat-square)](https://hub.docker.com/r/hyness/spring-cloud-config-server/builds/)
@@ -10,9 +11,9 @@ A docker image of [Spring Cloud Config Server](https://docs.spring.io/spring-clo
 [![License](https://img.shields.io/github/license/hyness/spring-cloud-config-server)](https://www.apache.org/licenses/LICENSE-2.0.html)
 
 ## Supported tags
-* `3.0.0-jdk8`, `3.0-jdk8`, `jdk8`, `3.0.0`, `3.0`, `latest`
-* `3.0.0-jdk11`, `3.0-jdk11`, `jdk11`
-* `3.0.0-jdk15`, `3.0-jdk15`, `jdk15`
+* `3.0.1-jdk8`, `3.0-jdk8`, `jdk8`, `3.0.1`, `3.0`, `latest`
+* `3.0.1-jdk11`, `3.0-jdk11`, `jdk11`
+* `3.0.1-jdk15`, `3.0-jdk15`, `jdk15`
 
 ## Usage
 ```

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,8 @@ tasks {
         manifest {
             attributes(
                     "Implementation-Title" to project.name,
-                    "Implementation-Version" to project.dependencyManagement.importedProperties["spring-cloud-config.version"]
+                    "Implementation-Version" to (project.properties["spring-cloud-config.version"] as String? ?:
+                        project.dependencyManagement.importedProperties["spring-cloud-config.version"])
             )
         }
     }
@@ -42,7 +43,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-redis")
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework:spring-jdbc")
-    implementation("org.springframework.vault:spring-vault-core:${properties["spring-vault.version"]}")
+    implementation("org.springframework.vault:spring-vault-core")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.jetbrains.kotlin:kotlin-stdlib")
     implementation("com.amazonaws:aws-java-sdk-s3:${properties["s3.version"]}")

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,5 +6,5 @@ springBootVersion=2.4.1
 springCloudVersion=2020.0.0
 springDependencyManagement=1.0.10.RELEASE
 org.gradle.vfs.watch=true
-spring-vault.version=2.3.0
+spring-cloud-config.version=3.0.1
 s3.version=1.11.935


### PR DESCRIPTION
- Allow Implementation-Version to be overridden in gradle.properties