### PR TITLE
Kill signal is not received

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-java -cp /opt/spring-cloud-config-server ${JAVA_OPTS} org.springframework.boot.loader.JarLauncher \
+exec java -cp /opt/spring-cloud-config-server ${JAVA_OPTS} org.springframework.boot.loader.JarLauncher \
 --server.port=8888 \
 --spring.config.name=application "$@"


### PR DESCRIPTION
When running the server with `docker run -p 8888:8888 -e SPRING_PROFILES_ACTIVE=native`, closing the process is not enough.
I have to resort to `docker kill`.
Adding `exec` allows the signal to be transmitted to the JVM and therefore fixes the issue.