### PR TITLE
Allow custom boot launcher usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,8 @@ COPY --from=builder /build/spring-boot-loader/ ./
 COPY --from=builder /build/application/ ./
 COPY entrypoint.sh ./
 
+ENV BOOT_LAUNCHER=org.springframework.boot.loader.JarLauncher
+
 WORKDIR /
 EXPOSE 8888
 VOLUME /config

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-java -cp /opt/spring-cloud-config-server ${JAVA_OPTS} org.springframework.boot.loader.JarLauncher \
+java -cp /opt/spring-cloud-config-server ${JAVA_OPTS} ${BOOT_LAUNCHER} \
 --server.port=8888 \
 --spring.config.name=application "$@"

--- a/jdk11.Dockerfile
+++ b/jdk11.Dockerfile
@@ -13,6 +13,8 @@ COPY --from=builder /build/spring-boot-loader/ ./
 COPY --from=builder /build/application/ ./
 COPY entrypoint.sh ./
 
+ENV BOOT_LAUNCHER=org.springframework.boot.loader.JarLauncher
+
 WORKDIR /
 EXPOSE 8888
 VOLUME /config

--- a/jdk15.Dockerfile
+++ b/jdk15.Dockerfile
@@ -13,6 +13,8 @@ COPY --from=builder /build/spring-boot-loader/ ./
 COPY --from=builder /build/application/ ./
 COPY entrypoint.sh ./
 
+ENV BOOT_LAUNCHER=org.springframework.boot.loader.JarLauncher
+
 WORKDIR /
 EXPOSE 8888
 VOLUME /config


### PR DESCRIPTION
I need to add a `spring-boot-starter` jar to the server loader path.
To do that, I had to extend the `Dockerfile` and change `entrypoint.sh` as follow.

Dockerfile :
```Dockerfile
FROM docker.cosium.dev/hyness/spring-cloud-config-server:3.0.2-jdk11

ENV LOADER_PATH=/foo.jar

COPY entrypoint.sh /opt/spring-cloud-config-server
COPY foo.jar /foo.jar
```

entrypoint.sh :
```shell
#!/bin/sh

exec java -cp /opt/spring-cloud-config-server ${JAVA_OPTS} org.springframework.boot.loader.PropertiesLauncher \
--server.port=8888 \
--spring.config.name=application "$@"
```

`entrypoint.sh` had to be replaced just to be able to change the launcher to `org.springframework.boot.loader.PropertiesLauncher`.

The current PR turns the boot launcher into an environment variable defaulting to `org.springframework.boot.loader.JarLauncher`. This will allow people to choose the launcher by just setting `BOOT_LAUNCHER` environment variable.