### PR TITLE
Add issue/PR templates and contributor docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,38 +1,34 @@
 ---
 name: Bug report
-about: Create a report to help us improve
+about: Report a problem with the Docker image or its configuration
 title: ''
-labels: ''
+labels: bug
 assignees: ''
 
 ---
 
 **Describe the bug**
-A clear and concise description of what the bug is.
+A clear and concise description of what's wrong.
 
 **To Reproduce**
-Steps to reproduce the behavior:
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
+The `docker run` / `docker-compose` command and any mounted configuration used to reproduce it:
+```
+docker run -it -p 8888:8888 \
+      -v /path/to/config:/config \
+      hyness/spring-cloud-config-server:<tag>
+```
 
 **Expected behavior**
 A clear and concise description of what you expected to happen.
 
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
+**Logs**
+Relevant output from `docker logs` (please redact secrets/credentials).
 
-**Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
-
-**Smartphone (please complete the following information):**
- - Device: [e.g. iPhone6]
- - OS: [e.g. iOS8.1]
- - Browser [e.g. stock browser, safari]
- - Version [e.g. 22]
+**Environment**
+ - Image tag: [e.g. 5.0.4-jre17]
+ - Platform: [e.g. linux/amd64, linux/arm64]
+ - Docker version: [e.g. output of `docker version`]
+ - Config format: [e.g. application.yml, environment variables, Git-backed]
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Spring Cloud Config Server documentation
+    url: https://docs.spring.io/spring-cloud-config/reference/
+    about: Configuration options, properties, and behavior of Spring Cloud Config Server itself.
+  - name: Spring Cloud Config upstream issue tracker
+    url: https://github.com/spring-cloud/spring-cloud-config/issues
+    about: Bugs or feature requests about Spring Cloud Config Server's behavior (not this Docker packaging).
+  - name: Docker Hub
+    url: https://hub.docker.com/r/hyness/spring-cloud-config-server
+    about: Available tags and pulling the image.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,8 +1,8 @@
 ---
 name: Feature request
-about: Suggest an idea for this project
+about: Suggest an idea for this image or its packaging
 title: ''
-labels: ''
+labels: enhancement
 assignees: ''
 
 ---
@@ -17,4 +17,4 @@ A clear and concise description of what you want to happen.
 A clear and concise description of any alternative solutions or features you've considered.
 
 **Additional context**
-Add any other context or screenshots about the feature request here.
+Note if this is a request for Spring Cloud Config Server itself (best raised upstream at [spring-cloud/spring-cloud-config](https://github.com/spring-cloud/spring-cloud-config)) versus something about this image/packaging (platforms, tags, base image, entrypoint behavior, etc.).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,10 @@
+## Summary
+
+<!-- What does this PR change, and why? -->
+
+## Test plan
+
+<!-- How did you verify this? e.g. `./gradlew test -PtestFilter=<backend>`, manual `docker run` -->
+
+- [ ] `./gradlew test` passes locally
+- [ ] CI is green (multi-arch image build + full backend integration matrix)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,33 @@
+# Contributing
+
+Thanks for taking the time to contribute!
+
+This repository packages [Spring Cloud Config Server](https://docs.spring.io/spring-cloud-config/reference/) as a
+Docker image. If your issue or idea is about Config Server's own behavior rather than this packaging, it's usually
+better raised upstream at [spring-cloud/spring-cloud-config](https://github.com/spring-cloud/spring-cloud-config).
+
+## Reporting bugs / requesting features
+
+Please use the issue templates when opening a new issue - they ask for the information needed to reproduce
+problems (image tag, platform, mounted configuration) up front.
+
+## Making changes
+
+1. Fork the repo and create a branch off `main`.
+2. Build the image and run the test suite locally:
+   ```
+   ./gradlew test
+   ```
+   Individual backend integration tests (each spins up its own testcontainer) can be run one at a time with:
+   ```
+   ./gradlew test -PtestFilter=<backend>
+   ```
+   where `<backend>` is one of the tags used in [`ci.yml`](.github/workflows/ci.yml), e.g. `git`, `redis`, `vault`,
+   `aws-s3`, `postgres`.
+3. Open a pull request against `main` using the PR template. CI builds the image for both `x64` and `arm` and runs
+   the full integration test matrix against every supported backend - a green run is required before merge.
+
+## Dependency updates
+
+Dependency bumps are managed by Renovate and open as a single grouped PR on a weekly schedule; you don't need to
+bump versions by hand.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,27 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you believe you've found a security vulnerability in this Docker image or its build/release pipeline, please
+report it privately using [GitHub Security Advisories](../../security/advisories/new) rather than opening a public
+issue.
+
+Please include:
+- The affected image tag(s)
+- Steps to reproduce, or a proof of concept
+- The potential impact
+
+You should expect an initial response within a few days.
+
+## Vulnerabilities in Spring Cloud Config Server itself
+
+This repository only packages Spring Cloud Config Server; it doesn't patch or modify its code. If the vulnerability
+is in Spring Cloud Config Server, Spring Boot, or another upstream dependency rather than in how this image is
+built, please also report it to the relevant upstream project (see [Spring's security policy](https://spring.io/security-policy)).
+Rebuilding this image against a patched dependency version is tracked the same way as any other dependency update
+([Renovate](https://github.com/renovatebot/renovate) opens the PR automatically once a fix is released).
+
+## Supported Versions
+
+Only the most recently published image tags receive updates. Older tags are not patched retroactively - please
+upgrade to the latest tag for your JVM/platform combination.


### PR DESCRIPTION
## Summary
- Rewrite the default GitHub issue templates (bug report / feature request) around this project - image tags, platforms, mounted config - instead of the generic browser/mobile-app fields
- Add an issue-template chooser (`config.yml`) with links to Spring Cloud Config Server's own docs/issue tracker for problems that aren't about this packaging
- Add `PULL_REQUEST_TEMPLATE.md`, `CONTRIBUTING.md`, and `SECURITY.md`, which the repo didn't have

## Test plan
- [ ] Open a new issue in the GitHub UI and confirm the template chooser and both templates render as expected