### PR TITLE
Add ARM builds support

### DIFF
--- a/.github/workflows/build-and-deploy-image.yml
+++ b/.github/workflows/build-and-deploy-image.yml
@@ -30,6 +30,10 @@ on:
       tags:
         description: Comma separated list of docker tags to create
         type: string
+      runner:
+        description: GitHub runner to use
+        type: string
+        default: ubuntu-latest
 
 jobs:
   generate-jvm-tag:
@@ -41,7 +45,7 @@ jobs:
   build-and-push:
     name: Build and deploy Java ${{ needs.generate-jvm-tag.outputs.jvm-tag }} OCI image to registry
     needs: generate-jvm-tag
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -71,7 +75,7 @@ jobs:
           echo "DOCKER_USERNAME=${{ github.actor }}" >> $GITHUB_ENV
           echo "DOCKER_PASSWORD=${{ secrets.GITHUB_TOKEN }}" >> $GITHUB_ENV
 
-      - name: Build and deploy OCI image
+      - name: Build and deploy OCI image on ${{ inputs.runner }}
         run: >
           ./gradlew bootBuildImage
           -PjvmType=${{ inputs.image-jvm-type }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  packages: write
+
 env:
   DISTRIBUTION: temurin
   JVM_TYPE: jre

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,17 +42,21 @@ jobs:
     needs:
       - build-vars
       - sha-tag
+    strategy:
+      matrix:
+        runner: [ubuntu-latest, ubuntu-24.04-arm]
     with:
       image-name: ${{ github.repository }}:${{ needs.sha-tag.outputs.tag }}
       registry: ${{ needs.build-vars.outputs.registry }}
+      runner: ${{ matrix.runner }}
 
   integration-test:
-    name: Verify OCI image with ${{ matrix.backend }}
+    name: Verify OCI image with ${{ matrix.backend }} on ${{ matrix.runner }}
     needs:
       - build-vars
       - build-and-deploy
       - sha-tag
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
@@ -72,6 +76,7 @@ jobs:
           security,
           vault
         ]
+        runner: [ubuntu-latest, ubuntu-24.04-arm]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -90,5 +95,6 @@ jobs:
           ./gradlew test -i
           -PtestFilter=${{ matrix.backend }}
           -PimageRegistry=${{ needs.build-vars.outputs.registry }}
+          -PimageName=${{ github.repository }}
           -PjdkVersion=${{ needs.build-vars.outputs.jvm-version }}
           -PimageTag=${{ needs.sha-tag.outputs.tag }}


### PR DESCRIPTION
## Summary

Replicates the work from [hyness/spring-cloud-config-server#151](https://github.com/hyness/spring-cloud-config-server/pull/151) with an additional fix for GHCR push permissions.

- Add `runner` input to `build-and-deploy-image.yml` reusable workflow, defaulting to `ubuntu-latest`
- Build and test OCI images on both `ubuntu-latest` (amd64) and `ubuntu-24.04-arm` (arm64) runners using a matrix strategy
- Pass `-PimageName` to Gradle in integration tests
- Add explicit `packages: write` permission to the CI workflow for GHCR image push

## Test plan

- [ ] Verify CI workflow triggers on PR and builds images for both architectures
- [x] Verify images are pushed to GHCR successfully
- [ ] Verify integration tests pass on both runners