### PR TITLE
Add multi-arch support with manifest lists

### DIFF
--- a/.github/workflows/build-and-deploy-image.yml
+++ b/.github/workflows/build-and-deploy-image.yml
@@ -3,6 +3,10 @@ name: Build and deploy OCI image to registry
 on:
   workflow_call:
     inputs:
+      arch:
+        description: Architecture to build (x64, arm)
+        type: string
+        default: x64
       image-jvm-type:
         description: JVM type for output image
         type: string
@@ -35,13 +39,16 @@ jobs:
   generate-jvm-tag:
     uses: ./.github/workflows/generate-jvm-tag.yml
     with:
-      jvm-type: ${{ inputs.jvm-type }}
-      jvm-version: ${{ inputs.jvm-version }}
+      jvm-type: ${{ inputs.image-jvm-type }}
+      jvm-version: ${{ inputs.image-jvm-version }}
 
   build-and-push:
-    name: Build and deploy Java ${{ needs.generate-jvm-tag.outputs.jvm-tag }} OCI image to registry
+    name: Build and deploy ${{ inputs.arch }} OCI image
     needs: generate-jvm-tag
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.arch == 'arm' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
+    outputs:
+      image-name: ${{ steps.outputs.outputs.image-name }}
+      arch: ${{ inputs.arch }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -57,7 +64,18 @@ jobs:
 
       - name: Add tags environment variable
         if: inputs.tags != ''
-        run: echo "TAGS=-PdockerTags=${{ inputs.tags }}" >> $GITHUB_ENV
+        run: |
+          IFS=',' read -ra TAG_ARRAY <<< "${{ inputs.tags }}"
+          ARCH_TAGS=""
+          for tag in "${TAG_ARRAY[@]}"; do
+            tag=$(echo "$tag" | xargs)
+            if [ -z "$ARCH_TAGS" ]; then
+              ARCH_TAGS="${tag}-${{ inputs.arch }}"
+            else
+              ARCH_TAGS="${ARCH_TAGS},${tag}-${{ inputs.arch }}"
+            fi
+          done
+          echo "DOCKER_TAGS=$ARCH_TAGS" >> $GITHUB_ENV
 
       - name: Setup Docker Hub credentials
         if: inputs.registry == 'docker.io'
@@ -72,6 +90,7 @@ jobs:
           echo "DOCKER_PASSWORD=${{ secrets.GITHUB_TOKEN }}" >> $GITHUB_ENV
 
       - name: Build and deploy OCI image
+        id: build
         run: >
           ./gradlew bootBuildImage
           -PjvmType=${{ inputs.image-jvm-type }}
@@ -79,5 +98,11 @@ jobs:
           -PdockerUsername=${{ env.DOCKER_USERNAME }}
           -PdockerPassword=${{ env.DOCKER_PASSWORD }}
           $TAGS
-          --imageName=${{ inputs.registry }}/${{ inputs.image-name }}
+          -PimagePlatform=${{ inputs.arch == 'arm' && 'linux/arm64' || 'linux/amd64' }}
+          --imageName="${{ inputs.registry }}/${{ inputs.image-name }}"
           --publishImage
+
+      - name: Output image name
+        id: outputs
+        run: |
+          echo "image-name=${{ inputs.registry }}/${{ inputs.image-name }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,15 @@ name: Build and test
 on:
   pull_request:
   workflow_dispatch:
+    inputs:
+      arch:
+        description: Architecture to build/test (x64, arm, all)
+        type: choice
+        options:
+          - x64
+          - arm
+          - all
+        default: all
 
 env:
   DISTRIBUTION: temurin
@@ -37,25 +46,30 @@ jobs:
       jvm-version: ${{ needs.build-vars.outputs.jvm-version }}
 
   build-and-deploy:
-    name: Build and deploy OCI image
+    name: Build and deploy ${{ matrix.arch }} OCI image
     uses: ./.github/workflows/build-and-deploy-image.yml
     needs:
       - build-vars
       - sha-tag
+    strategy:
+      matrix:
+        arch: [x64, arm]
     with:
-      image-name: ${{ github.repository }}:${{ needs.sha-tag.outputs.tag }}
+      image-name: ${{ github.repository }}:${{ needs.sha-tag.outputs.tag }}-${{ matrix.arch }}
       registry: ${{ needs.build-vars.outputs.registry }}
+      arch: ${{ matrix.arch }}
 
   integration-test:
-    name: Verify OCI image with ${{ matrix.backend }}
+    name: Verify ${{ matrix.arch }} OCI image with ${{ matrix.backend }}
     needs:
       - build-vars
       - build-and-deploy
       - sha-tag
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.arch == 'arm' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:
+        arch: [x64, arm]
         backend: [
           aws-param-store,
           aws-s3,
@@ -88,7 +102,9 @@ jobs:
       - name: Test with ${{ matrix.backend }}
         run: >
           ./gradlew test -i
+          -Dtestcontainers.socat.image=alpine/socat:1.7.4.4
           -PtestFilter=${{ matrix.backend }}
           -PimageRegistry=${{ needs.build-vars.outputs.registry }}
+          -PimageName=${{ github.repository }}
           -PjdkVersion=${{ needs.build-vars.outputs.jvm-version }}
-          -PimageTag=${{ needs.sha-tag.outputs.tag }}
+          -PimageTag=${{ needs.sha-tag.outputs.tag }}-${{ matrix.arch }}

--- a/.github/workflows/generate-arch-vars.yml
+++ b/.github/workflows/generate-arch-vars.yml
@@ -1,0 +1,30 @@
+name: Generate a runs-on image name for an architecture
+
+on:
+  workflow_call:
+    inputs:
+      arch:
+        description: Image to use for the given architecture
+        type: string
+        required: true
+    outputs:
+      runs-on-image-name:
+        description: Runs on image name for the given architecture
+        value: ${{ jobs.generate-runs-on-image-name.outputs.runs-on-image-name }}
+      image-platform:
+        description: Image platform for the given architecture
+        value: ${{ jobs.generate-runs-on-image-name.outputs.image-platform }}
+
+jobs:
+  generate-runs-on-image-name:
+    name: Generate an arch runs-on image name
+    runs-on: ubuntu-latest
+    outputs:
+      runs-on-image-name: ${{ steps.write-tag.outputs.runs-on-image-name }}
+      image-platform: ${{ steps.write-tag.outputs.runs-on-image-name }}
+    steps:
+      - name: Write output
+        id: write-runs-on-image-name
+        run: |
+          echo "runs-on-image-name=${{ inputs.arch == 'arm' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}" >> $GITHUB_OUTPUT
+          echo "image-platform=${{ inputs.arch == 'arm' && 'linux/arm64' || 'linux/amd64' }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/generate-docker-tags.yml
+++ b/.github/workflows/generate-docker-tags.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Remove prefix, if necessary
         run: |
-          echo "BUILD_VERSION=`echo "${{ inputs.build-version }} | sed 's/.* -> //'`" >> $GITHUB_ENV
+          echo "BUILD_VERSION=`echo "${{ inputs.build-version }}" | sed 's/.* -> //'`" >> $GITHUB_ENV
 
       - name: Determine if latest version
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,16 +50,57 @@ jobs:
       jvm-version: ${{ inputs.jvm-version }}
 
   build-and-deploy:
-    name: Build and deploy Java ${{ needs.jvm-tag.outputs.jvm-tag }} OCI image to registry
+    name: Build and deploy Java ${{ needs.jvm-tag.outputs.jvm-tag }} ${{ matrix.arch }} OCI image to registry
     uses: ./.github/workflows/build-and-deploy-image.yml
     needs:
       - docker-tags
       - jvm-tag
       - sha-tag
+    strategy:
+      matrix:
+        arch: [x64, arm]
     with:
-      image-name: ${{ inputs.image-name }}:${{ needs.sha-tag.outputs.tag }}
+      image-name: ${{ inputs.image-name }}:${{ needs.sha-tag.outputs.tag }}-${{ matrix.arch }}
       image-jvm-version: ${{ inputs.jvm-version }}
       image-jvm-type: ${{ inputs.jvm-type }}
       registry: ${{ inputs.registry }}
       tags: ${{ needs.docker-tags.outputs.tags }}
+      arch: ${{ matrix.arch }}
     secrets: inherit
+
+  create-manifests:
+    name: Create multi-arch manifests
+    runs-on: ubuntu-latest
+    needs:
+      - docker-tags
+      - jvm-tag
+      - build-and-deploy
+      - sha-tag
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        if: inputs.registry == 'docker.io'
+        run: |
+          echo "${{ secrets.DOCKERHUB_TOKEN }}" | docker login ${{ inputs.registry }} -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
+
+      - name: Login to GitHub Container Registry
+        if: inputs.registry == 'ghcr.io'
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ${{ inputs.registry }} -u ${{ github.actor }} --password-stdin
+
+      - name: Create manifests for each tag
+        run: |
+          IFS=',' read -ra FULL_TAGS <<< "${{ needs.docker-tags.outputs.tags }}"
+          for full_tag in "${FULL_TAGS[@]}"; do
+            full_tag=$(echo "$full_tag" | xargs)
+            echo "Creating manifest for $full_tag"
+            docker manifest create $full_tag \
+              ${full_tag}-x64 \
+              ${full_tag}-arm
+            docker manifest push $full_tag
+          done

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ A docker image of [Spring Cloud Config Server](https://docs.spring.io/spring-clo
 * `5.0.1-jre21`, `5.0-jre21`, `jre21`
 * `5.0.1-jdk21`, `5.0-jdk21`, `jdk21`
 
+### Supported Platforms
+* arm
+* x64
+
 ### Usage
 ```
 docker run -it --name=spring-cloud-config-server \

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -72,8 +72,7 @@ tasks {
             "BPE_THC_PATH" to "/actuator/health",
             "BPE_THC_PORT" to "8888"
         )
-        imageName = "hyness/spring-cloud-config-server"
-        tags = dockerTags?.split(',')
+        tags = (dockerTags ?: System.getenv("DOCKER_TAGS"))?.split(',')?.filter { it.isNotBlank() }
     }
 }
 

--- a/examples/aws/paramstore/compose.yml
+++ b/examples/aws/paramstore/compose.yml
@@ -75,7 +75,7 @@ services:
       - --spring.cloud.config.server.awsparamstore.region=us-east-1
 
   localstack:
-    image: localstack/localstack:stable
+    image: localstack/localstack:3.8.1
     networks:
       aws:
         aliases:

--- a/examples/aws/s3/compose.yml
+++ b/examples/aws/s3/compose.yml
@@ -77,7 +77,7 @@ services:
         - --spring.cloud.config.server.awss3.bucket=sample-bucket
 
   localstack:
-    image: localstack/localstack:stable
+    image: localstack/localstack:3.8.1
     networks:
       aws:
         aliases:

--- a/examples/aws/secretsmanager/compose.yml
+++ b/examples/aws/secretsmanager/compose.yml
@@ -75,7 +75,7 @@ services:
         - --spring.cloud.config.server.aws-secretsmanager.region=us-east-1
 
   localstack:
-    image: localstack/localstack:stable
+    image: localstack/localstack:3.8.1
     networks:
       aws:
         aliases:


### PR DESCRIPTION
## Summary

- Build both x64 and arm OCI images for all JVM variants (jre17, jdk17, jre21, jdk21)
- Create Docker manifest lists so consumers get the right image automatically via a single tag
- CI integration tests run on both architectures (28 jobs: 14 backends × 2 archs)
- Fix ARM test failures by overriding Testcontainers socat image to multi-arch version
- Pin localstack to 3.8.1 (newer versions require authentication)
- Fix missing quote in `generate-docker-tags.yml` BUILD_VERSION generation

## How it works

1. Both x64 and arm images are built with arch-specific tags (e.g., `5.0.1-jre17-x64`, `5.0.1-jre17-arm`)
2. A manifest list is created at the consumer tag (e.g., `5.0.1-jre17`) pointing to both arch images
3. Docker automatically resolves the correct image when pulling the consumer tag
4. CI tests run on both architectures, each pulling its matching arch-specific tag

## Changes

- `build.gradle.kts` — Read `DOCKER_TAGS` from env var; support `--imagePlatform` CLI flag
- `.github/workflows/ci.yml` — Build both archs, test on both archs with arch-specific tags
- `.github/workflows/release.yml` — Build both archs, create manifest lists for consumer tags
- `.github/workflows/build-and-deploy-image.yml` — Pass `--imagePlatform` and append arch to tags
- `.github/workflows/generate-docker-tags.yml` — Fix missing quote in BUILD_VERSION
- `examples/aws/*/compose.yml` — Pin localstack to 3.8.1

Co-authored-by: Alex Kurdyukov <akurdyukov@users.noreply.github.com>