### PR TITLE
Update to 5.0.5

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,8 +4,8 @@ aws-msk-iam-auth = "2.3.5"
 kotlin = "2.3.20"
 kotlin-logging = "8.0.01"
 spring-boot = "4.0.5"
-spring-cloud = "2025.1.2"
-spring-cloud-config = "5.0.4"
+spring-cloud = "2025.1.3"
+spring-cloud-config = "5.0.5"
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }


### PR DESCRIPTION
Bumps spring-cloud 2025.1.2 -> 2025.1.3 and spring-cloud-config 5.0.4 -> 5.0.5.

Test run for the new auto-release automation: merging this (labeled `dependencies`, which changes `spring-cloud-config`'s version) should trigger `auto-release.yml` to update the README's supported-tags block, tag `v5.0.5`, and cut the release, which in turn fires `deploy.yml`.