### PR TITLE
Add weekly Trivy scan of published image

### DIFF
--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -1,0 +1,31 @@
+name: Trivy vulnerability scan
+
+on:
+  schedule:
+    - cron: '0 8 * * 0'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  scan:
+    name: Scan latest published image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: docker.io/hyness/spring-cloud-config-server:latest
+          format: sarif
+          output: trivy-results.sarif
+          severity: 'CRITICAL,HIGH,MEDIUM,LOW'
+
+      - name: Upload results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-results.sarif

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 A docker image of [Spring Cloud Config Server](https://docs.spring.io/spring-cloud-config/reference/).
 
 ![CI Build](https://github.com/hyness/spring-cloud-config-server/actions/workflows/ci.yml/badge.svg)
+[![Trivy Scan](https://github.com/hyness/spring-cloud-config-server/actions/workflows/trivy-scan.yml/badge.svg)](https://github.com/hyness/spring-cloud-config-server/security/code-scanning)
 ![Docker Image Version (latest semver)](https://img.shields.io/docker/v/hyness/spring-cloud-config-server?sort=semver)
 [![Docker Stars](https://img.shields.io/docker/stars/hyness/spring-cloud-config-server.svg?style=flat)](https://hub.docker.com/r/hyness/spring-cloud-config-server/)
 [![Docker Pulls](https://img.shields.io/docker/pulls/hyness/spring-cloud-config-server.svg?style=flat)](https://hub.docker.com/r/hyness/spring-cloud-config-server)


### PR DESCRIPTION
## Summary
- Add .github/workflows/trivy-scan.yml: scans docker.io/hyness/spring-cloud-config-server:latest weekly (and on manual dispatch), uploads results as SARIF to GitHub's code scanning (Security tab) - same pattern as codeql.yml, but for the built image's dependencies/OS packages rather than source code.
- This is what #158 caught manually - now it happens continuously, and findings will show up as GitHub code scanning alerts instead of relying on someone running Trivy by hand and filing an issue.
- Add a README badge linking to the workflow / Security tab.

Note: the badge reflects whether the scan *ran*, not whether the image is clean - actual findings live at Security > Code scanning, not in the badge color.

## Test plan
- [ ] Manually trigger the workflow once merged and confirm results appear under Security > Code scanning