### PR TITLE
Add README supported-tags update, triggered by manual releases

### DIFF
--- a/.github/workflows/update-readme-tags.yml
+++ b/.github/workflows/update-readme-tags.yml
@@ -1,0 +1,61 @@
+name: Update README supported tags
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  update-readme:
+    name: Update Supported tags section
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.RENOVATE_APP_ID }}
+          private-key: ${{ secrets.RENOVATE_APP_PRIVATE_KEY }}
+
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Update README supported tags
+        env:
+          VERSION: ${{ github.event.release.tag_name }}
+        run: |
+          VERSION=${VERSION#v}
+          MAJOR_MINOR=$(echo "$VERSION" | cut -d. -f1,2)
+          {
+            printf '* `%s-jre17`, `%s-jre17`, `jre17`, `%s`, `%s`, `latest`\n' "$VERSION" "$MAJOR_MINOR" "$VERSION" "$MAJOR_MINOR"
+            printf '* `%s-jdk17`, `%s-jdk17`, `jdk17`\n' "$VERSION" "$MAJOR_MINOR"
+            printf '* `%s-jre21`, `%s-jre21`, `jre21`\n' "$VERSION" "$MAJOR_MINOR"
+            printf '* `%s-jdk21`, `%s-jdk21`, `jdk21`\n' "$VERSION" "$MAJOR_MINOR"
+          } > /tmp/supported-tags.md
+          awk -v block_file=/tmp/supported-tags.md '
+            /^### Supported tags$/ {
+              print
+              while ((getline line < block_file) > 0) print line
+              skip=1
+              next
+            }
+            skip && /^$/ { skip=0 }
+            skip { next }
+            { print }
+          ' README.md > README.md.new
+          mv README.md.new README.md
+
+      - name: Commit README update
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          if ! git diff --quiet README.md; then
+            git add README.md
+            git commit -m "Update supported tags for ${{ github.event.release.tag_name }}"
+            git push origin main
+          fi


### PR DESCRIPTION
## Summary
- Add .github/workflows/update-readme-tags.yml
- auto-release.yml (removed in a previous PR) auto-updated the README's "Supported tags" section as a side effect of auto-creating a release. That side effect was useful on its own, the auto-creation wasn't.
- This recreates just the README update, triggered by `release: published` - so it only fires after you manually create a release, not before.

## Test plan
- [ ] Cut a real release and confirm the Supported tags section updates and gets committed to main automatically